### PR TITLE
Fix: connection reset error when fetching next track URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wheels/
 
 # textual exemple
 textual/
+.beads/

--- a/src/ttydal/pages/player_page.py
+++ b/src/ttydal/pages/player_page.py
@@ -74,6 +74,8 @@ class PlayerPage(Container):
         log(f"  - Track: {event.track_info.get('name', 'Unknown')}")
         log(f"  - Track ID: {event.track_id}")
         log(f"  - Artist: {event.track_info.get('artist', 'Unknown')}")
+        if event.prefetched_url:
+            log("  - Has pre-fetched URL: Yes")
 
         # Use PlaybackService to handle playback
         result = self.playback_service.play_track(
@@ -81,6 +83,9 @@ class PlayerPage(Container):
             event.track_info,
             self.config.quality,
             fetch_vibrant_color=self.config.vibrant_color,
+            prefetched_url=event.prefetched_url,
+            prefetched_metadata=event.prefetched_metadata,
+            prefetched_error_info=event.prefetched_error_info,
         )
 
         if result.success:

--- a/src/ttydal/services/playback_service.py
+++ b/src/ttydal/services/playback_service.py
@@ -39,6 +39,9 @@ class PlaybackService:
         track_info: dict[str, Any],
         quality: str = "high",
         fetch_vibrant_color: bool = False,
+        prefetched_url: str | None = None,
+        prefetched_metadata: dict | None = None,
+        prefetched_error_info: dict | None = None,
     ) -> PlaybackResult:
         """Play a track by ID with quality setting.
 
@@ -47,6 +50,9 @@ class PlaybackService:
             track_info: Track metadata dictionary (name, artist, etc.)
             quality: Quality setting ('max', 'high', or 'low')
             fetch_vibrant_color: Whether to include the album's vibrant color
+            prefetched_url: Pre-fetched stream URL (skips API call if provided)
+            prefetched_metadata: Pre-fetched stream metadata
+            prefetched_error_info: Pre-fetched error info dict
 
         Returns:
             PlaybackResult with success status and metadata
@@ -58,11 +64,17 @@ class PlaybackService:
         log(f"  - Artist: {track_info.get('artist', 'Unknown')}")
         log(f"  - Requested quality: {quality}")
 
-        # Get track URL and metadata from Tidal
-        log("  - Requesting track URL and metadata from Tidal...")
-        track_url, stream_metadata, error_info = self.tidal.get_track_url(
-            track_id, quality
-        )
+        # Use pre-fetched data if available, otherwise fetch from Tidal
+        if prefetched_url and prefetched_metadata:
+            log("  - Using pre-fetched URL (skipping API call)")
+            track_url = prefetched_url
+            stream_metadata = prefetched_metadata
+            error_info = prefetched_error_info or {}
+        else:
+            log("  - Requesting track URL and metadata from Tidal...")
+            track_url, stream_metadata, error_info = self.tidal.get_track_url(
+                track_id, quality
+            )
 
         if track_url and stream_metadata:
             log("  - Got track URL, calling player.play()")


### PR DESCRIPTION
## Problem
HTTP connection becomes stale during song playback (3-5 min), causing `ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))` when fetching the next track URL.

## Solution
1. **Retry decorator** - Exponential backoff for API calls (handles transient failures)
2. **Pre-fetch** - Fetch next track URL 15 seconds before current track ends (prevents stale connection)

## Files changed
- `tidal_client.py` - Added retry decorator, applied to API methods
- `tracks_list.py` - Added pre-fetch logic watching playback position
- `playback_service.py` - Accept pre-fetched URL to skip API call
- `player_page.py` - Pass pre-fetched data through