### PR TITLE
Add configurable keybindings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project is heavily inspired by what [Maxteabag](https://github.com/Maxteaba
 - Player bar displaying track info, artist, album, playback time, and quality metrics
 - Multiple theme options for interface customization
 - Fully keyboard-driven interface
+- `new` Configurable keybindings - customize all keyboard shortcuts (see [KEYBINDINGS.md](docs/KEYBINDINGS.md))
 - Settings auto-save on change
 - Cover art display in albums list, tracks list, and player bar
 - Image caching for cover art
@@ -108,55 +109,7 @@ ttydal
 
 ## Keybindings
 
-### Navigation
-
-| Key | Action |
-|-----|--------|
-| `p` | Switch to Player page |
-| `c` | Switch to Config page |
-| `a` | Focus Albums/Playlists list |
-| `t` | Focus Tracks list |
-| `up/down` | Navigate through lists |
-| `enter` | Select item / Play track (always starts from beginning) |
-| `/` | Open fuzzy search |
-
-### Search Modal
-
-| Key | Action |
-|-----|--------|
-| `enter` | Navigate to selected album/track |
-| `space` | Play selected track (tracks only) |
-| `escape` | Close search |
-
-### Playback Controls
-
-| Key | Action |
-|-----|--------|
-| `space` | Toggle play/pause (works anywhere on player page) |
-| `shift+left` | Seek backward 10 seconds |
-| `shift+right` | Seek forward 10 seconds |
-| `N` (shift+n) | Play next track |
-| `P` (shift+p) | Play previous track |
-| `n` | Toggle auto-play next track on/off |
-| `s` | Toggle shuffle mode on/off |
-| `r` | Refresh current list (also clears relevant cache) |
-| `i` | Open cache info modal |
-| `v` | Toggle vibrant mode |
-
-### Login Modal
-
-| Key | Action |
-|-----|--------|
-| `o` | Open login URL in browser |
-| `c` | Copy login URL to clipboard |
-| `l` | Check login status |
-| `escape` | Close modal |
-
-### Application
-
-| Key | Action |
-|-----|--------|
-| `q` | Quit application |
+All keybindings are configurable. See [KEYBINDINGS.md](docs/KEYBINDINGS.md) for the full reference and instructions on customizing them.
 
 ## Configuration
 

--- a/src/ttydal/__init__.py
+++ b/src/ttydal/__init__.py
@@ -1,13 +1,70 @@
 """ttydal - Tidal in your terminal!"""
 
+import argparse
 import sys
 import traceback
-from ttydal.logger import log
-from ttydal.app import TtydalApp
+from ttydal.config import ConfigManager
 
 
 def main() -> None:
     """Launch the ttydal TUI application."""
+    from ttydal.dirs import config_dir, log_dir
+
+    cfg_dir = config_dir()
+    log_path = log_dir() / "debug.log"
+
+    parser = argparse.ArgumentParser(
+        prog="ttydal",
+        usage="ttydal [-h] [--init-config [--force]] [--debug]",
+        description="Tidal in your terminal!",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            f"config:\n"
+            f"  Config is stored at {cfg_dir}/config.json\n"
+            f"  Run --init-config to create one from defaults\n"
+            f"  The app works without a config file (uses bundled defaults)\n"
+            f"\n"
+            f"logs:\n"
+            f"  Debug logs are written to {log_path}\n"
+            f"  Enable with --debug or set debug_logging_enabled in config"
+        ),
+    )
+    parser.add_argument(
+        "--init-config",
+        action="store_true",
+        help=f"create default config at {cfg_dir}/config.json",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing config (only with --init-config)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="enable debug logging (overrides config)",
+    )
+    args = parser.parse_args()
+
+    if args.force and not args.init_config:
+        parser.error("--force can only be used with --init-config")
+
+    if args.init_config:
+        try:
+            path = ConfigManager.init_config(force=args.force)
+            print(f"Config created at {path}")
+        except FileExistsError as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+        return
+
+    config = ConfigManager()
+    if args.debug:
+        config._debug_override = True
+
+    from ttydal.logger import log
+    from ttydal.app import TtydalApp
+
     log("=" * 80)
     log("Starting ttydal application")
     log("=" * 80)

--- a/src/ttydal/app.py
+++ b/src/ttydal/app.py
@@ -21,6 +21,9 @@ from ttydal.components.tracks_list import TracksList
 from ttydal.services.tracks_cache import TracksCache
 from ttydal.config import ConfigManager
 from ttydal.logger import log
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("app", action)
 
 
 class TtydalApp(App):
@@ -41,21 +44,21 @@ class TtydalApp(App):
     """
 
     BINDINGS = [
-        Binding("p", "show_player", "Player", show=True),
-        Binding("c", "show_config", "Config", show=True),
-        Binding("a", "focus_albums", "Albums", show=True),
-        Binding("t", "focus_tracks", "Tracks", show=True),
-        Binding("/", "open_search", "Search", show=True),
-        Binding("i", "open_cache_info", "Cache", show=True),
-        Binding("space", "toggle_play", "Play/Pause", show=True),
-        Binding("n", "toggle_auto_play", "Auto-Play", show=True),
-        Binding("s", "toggle_shuffle", "Shuffle", show=True),
-        Binding("v", "toggle_vibrant_color", "Vibrant", show=True),
-        Binding("shift+left", "seek_backward", "Seek -10s", show=True),
-        Binding("shift+right", "seek_forward", "Seek +10s", show=True),
-        Binding("P", "play_previous", "Previous", show=True),
-        Binding("N", "play_next", "Next", show=True),
-        Binding("q", "quit", "Quit", show=True),
+        Binding(_k("show_player"), "show_player", "Player", show=True),
+        Binding(_k("show_config"), "show_config", "Config", show=True),
+        Binding(_k("focus_albums"), "focus_albums", "Albums", show=True),
+        Binding(_k("focus_tracks"), "focus_tracks", "Tracks", show=True),
+        Binding(_k("open_search"), "open_search", "Search", show=True),
+        Binding(_k("open_cache_info"), "open_cache_info", "Cache", show=True),
+        Binding(_k("toggle_play"), "toggle_play", "Play/Pause", show=True),
+        Binding(_k("toggle_auto_play"), "toggle_auto_play", "Auto-Play", show=True),
+        Binding(_k("toggle_shuffle"), "toggle_shuffle", "Shuffle", show=True),
+        Binding(_k("toggle_vibrant_color"), "toggle_vibrant_color", "Vibrant", show=True),
+        Binding(_k("seek_backward"), "seek_backward", "Seek -10s", show=True),
+        Binding(_k("seek_forward"), "seek_forward", "Seek +10s", show=True),
+        Binding(_k("play_previous"), "play_previous", "Previous", show=True),
+        Binding(_k("play_next"), "play_next", "Next", show=True),
+        Binding(_k("quit"), "quit", "Quit", show=True),
     ]
 
     def __init__(self):

--- a/src/ttydal/components/albums_list.py
+++ b/src/ttydal/components/albums_list.py
@@ -17,13 +17,20 @@ from ttydal.services import AlbumsService, TracksService, TidalServiceError
 from ttydal.services.tracks_cache import TracksCache
 from ttydal.logger import log
 from ttydal.components.cover_art_item import CoverArtItem
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("albums_list", action)
+_nav = lambda action: get_key("navigation", action)
 
 
 class AlbumsList(Container):
     """Albums list widget for browsing user albums."""
 
     BINDINGS = [
-        Binding("r", "refresh_albums", "Refresh", show=True),
+        Binding(_k("refresh_albums"), "refresh_albums", "Refresh", show=True),
+        Binding(_nav("cursor_down"), "cursor_down", "Down", show=False),
+        Binding(_nav("cursor_up"), "cursor_up", "Up", show=False),
+        Binding(_nav("cursor_right"), "focus_tracks", "Tracks", show=False),
     ]
 
     DEFAULT_CSS = """
@@ -378,6 +385,27 @@ class AlbumsList(Container):
         self._preload_in_progress = False
         self._trigger_preload_after_refresh = True
         self.load_albums()
+
+    def action_cursor_down(self) -> None:
+        """Move cursor down in the list."""
+        list_view = self.query_one("#albums-listview", ListView)
+        list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move cursor up in the list."""
+        list_view = self.query_one("#albums-listview", ListView)
+        list_view.action_cursor_up()
+
+    def action_focus_tracks(self) -> None:
+        """Move focus to tracks list."""
+        from ttydal.components.tracks_list import TracksList
+
+        try:
+            tracks_list = self.app.query_one(TracksList)
+            list_view = tracks_list.query_one("#tracks-listview")
+            list_view.focus()
+        except Exception:
+            pass
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Handle album or playlist selection.

--- a/src/ttydal/components/cache_modal.py
+++ b/src/ttydal/components/cache_modal.py
@@ -18,6 +18,7 @@ class CacheModal(ModalScreen):
 
     BINDINGS = [
         Binding(_k("close_modal"), "close_modal", "Close", show=True),
+        Binding("q", "app.quit", "Quit", show=False),
     ]
 
     CSS = """

--- a/src/ttydal/components/cache_modal.py
+++ b/src/ttydal/components/cache_modal.py
@@ -8,13 +8,16 @@ from textual.widgets import Label, Rule, Static
 
 from ttydal.services.tracks_cache import TracksCache
 from ttydal.services.image_cache import ImageCache
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("cache_modal", action)
 
 
 class CacheModal(ModalScreen):
     """Modal screen displaying cache statistics."""
 
     BINDINGS = [
-        Binding("escape", "close_modal", "Close", show=True),
+        Binding(_k("close_modal"), "close_modal", "Close", show=True),
     ]
 
     CSS = """

--- a/src/ttydal/components/login_modal.py
+++ b/src/ttydal/components/login_modal.py
@@ -11,16 +11,19 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Static
 
 from ttydal.logger import log
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("login_modal", action)
 
 
 class LoginModal(ModalScreen):
     """Modal screen for Tidal OAuth login."""
 
     BINDINGS = [
-        Binding("o", "open_url", "Open URL", show=True),
-        Binding("c", "copy_url", "Copy URL", show=True),
-        Binding("l", "check_login", "Check Login", show=True),
-        Binding("escape", "close_modal", "Close", show=True),
+        Binding(_k("open_url"), "open_url", "Open URL", show=True),
+        Binding(_k("copy_url"), "copy_url", "Copy URL", show=True),
+        Binding(_k("check_login"), "check_login", "Check Login", show=True),
+        Binding(_k("close_modal"), "close_modal", "Close", show=True),
     ]
 
     CSS = """

--- a/src/ttydal/components/search_modal.py
+++ b/src/ttydal/components/search_modal.py
@@ -10,6 +10,9 @@ from textual.screen import ModalScreen
 from textual.widgets import Input, ListView, ListItem, Label
 
 from ttydal.logger import log
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("search_modal", action)
 
 
 class SearchResultItem(ListItem):
@@ -54,9 +57,9 @@ class SearchModal(ModalScreen):
     """Modal screen for fuzzy searching albums and tracks."""
 
     BINDINGS = [
-        Binding("escape", "close_modal", "Close", show=True),
-        Binding("enter", "select_result", "Go to Album", show=True, priority=True),
-        Binding("space", "play_track", "Play Track", show=True, priority=True),
+        Binding(_k("close_modal"), "close_modal", "Close", show=True),
+        Binding(_k("select_result"), "select_result", "Go to Album", show=True, priority=True),
+        Binding(_k("play_track"), "play_track", "Play Track", show=True, priority=True),
     ]
 
     CSS = """

--- a/src/ttydal/components/tracks_list.py
+++ b/src/ttydal/components/tracks_list.py
@@ -13,6 +13,10 @@ from ttydal.services import TracksService, TidalServiceError
 from ttydal.services.tracks_cache import TracksCache
 from ttydal.logger import log
 from ttydal.components.cover_art_item import CoverArtItem
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("tracks_list", action)
+_nav = lambda action: get_key("navigation", action)
 
 
 # Pre-fetch next track URL this many seconds before current track ends
@@ -23,8 +27,11 @@ class TracksList(Container):
     """Tracks list widget for browsing and selecting tracks."""
 
     BINDINGS = [
-        Binding("enter", "play_selected_track", "Play Track", show=True),
-        Binding("r", "refresh_tracks", "Refresh", show=True),
+        Binding(_k("play_selected_track"), "play_selected_track", "Play Track", show=True),
+        Binding(_k("refresh_tracks"), "refresh_tracks", "Refresh", show=True),
+        Binding(_nav("cursor_down"), "cursor_down", "Down", show=False),
+        Binding(_nav("cursor_up"), "cursor_up", "Up", show=False),
+        Binding(_nav("cursor_left"), "focus_albums", "Albums", show=False),
     ]
 
     DEFAULT_CSS = """
@@ -658,6 +665,27 @@ class TracksList(Container):
             )
         else:
             log("  - No tracks loaded yet, nothing to refresh")
+
+    def action_cursor_down(self) -> None:
+        """Move cursor down in the list."""
+        list_view = self.query_one("#tracks-listview", ListView)
+        list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move cursor up in the list."""
+        list_view = self.query_one("#tracks-listview", ListView)
+        list_view.action_cursor_up()
+
+    def action_focus_albums(self) -> None:
+        """Move focus to albums list."""
+        from ttydal.components.albums_list import AlbumsList
+
+        try:
+            albums_list = self.app.query_one(AlbumsList)
+            list_view = albums_list.query_one("#albums-listview")
+            list_view.focus()
+        except Exception:
+            pass
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Handle track selection (Enter key or double-click).

--- a/src/ttydal/config.py
+++ b/src/ttydal/config.py
@@ -9,6 +9,7 @@ import json
 import shutil
 from importlib import resources
 from typing import Any
+from pathlib import Path
 
 from ttydal.dirs import config_dir
 
@@ -34,8 +35,14 @@ class ConfigManager:
         self.config_file = self.config_dir / "config.json"
         self._config: dict[str, Any] = {}
         self._debug_override: bool = False
+        self._ensure_dir(self.config_dir)
         self._load_config()
         self._initialized = True
+
+    @staticmethod
+    def _ensure_dir(path: Path) -> None:
+        """Create a directory (and parents) if it doesn't exist."""
+        path.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def _get_default_config() -> dict[str, Any]:
@@ -49,10 +56,10 @@ class ConfigManager:
 
     def _load_config(self) -> None:
         """Load configuration from file, falling back to bundled defaults."""
-        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self._ensure_dir(self.config_dir)
 
         if self.config_file.exists():
-            with open(self.config_file, "r") as f:
+            with open(self.config_file, "r", encoding="utf-8") as f:
                 self._config = json.load(f)
         else:
             # No user config — use bundled defaults (don't write to disk)
@@ -71,7 +78,6 @@ class ConfigManager:
         Raises:
             FileExistsError: If config already exists and force is False.
         """
-        from pathlib import Path
         cfg_dir = config_dir()
         cfg_file = cfg_dir / "config.json"
 
@@ -87,7 +93,8 @@ class ConfigManager:
 
     def _save_config(self) -> None:
         """Save configuration to file."""
-        with open(self.config_file, "w") as f:
+        self._ensure_dir(self.config_dir)
+        with open(self.config_file, "w", encoding="utf-8") as f:
             json.dump(self._config, f, indent=2)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/ttydal/config.py
+++ b/src/ttydal/config.py
@@ -1,9 +1,13 @@
 """Configuration manager for ttydal.
 
 Manages application configuration stored in the platform config directory.
+Run `ttydal --init-config` to create a config file from bundled defaults.
+The app works without a config file (uses bundled defaults in-memory).
 """
 
 import json
+import shutil
+from importlib import resources
 from typing import Any
 
 from ttydal.dirs import config_dir
@@ -29,26 +33,57 @@ class ConfigManager:
         self.config_dir = config_dir()
         self.config_file = self.config_dir / "config.json"
         self._config: dict[str, Any] = {}
+        self._debug_override: bool = False
         self._load_config()
         self._initialized = True
 
+    @staticmethod
+    def _get_default_config() -> dict[str, Any]:
+        """Load the default configuration from the bundled default_config.json."""
+        default_config_file = resources.files("ttydal").joinpath("default_config.json")
+        return json.loads(default_config_file.read_text(encoding="utf-8"))
+
+    def _get_default_keybindings(self) -> dict[str, dict[str, str]]:
+        """Get default keybindings configuration."""
+        return self._get_default_config().get("keybindings", {})
+
     def _load_config(self) -> None:
-        """Load configuration from file or create default config."""
+        """Load configuration from file, falling back to bundled defaults."""
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
         if self.config_file.exists():
             with open(self.config_file, "r") as f:
                 self._config = json.load(f)
         else:
-            # Default configuration
-            self._config = {
-                "theme": "rose-pine",
-                "quality": "high",  # high or low
-                "auto_play": True,  # auto-play next track when current finishes
-                "debug_logging_enabled": False,  # enable debug logging
-                "api_logging_enabled": False,  # enable API request/response logging
-            }
-            self._save_config()
+            # No user config — use bundled defaults (don't write to disk)
+            self._config = self._get_default_config()
+
+    @staticmethod
+    def init_config(force: bool = False) -> "Path":
+        """Copy the bundled default config to the platform config directory.
+
+        Args:
+            force: Overwrite existing config if True.
+
+        Returns:
+            Path to the created config file.
+
+        Raises:
+            FileExistsError: If config already exists and force is False.
+        """
+        from pathlib import Path
+        cfg_dir = config_dir()
+        cfg_file = cfg_dir / "config.json"
+
+        if cfg_file.exists() and not force:
+            raise FileExistsError(
+                f"Config already exists at {cfg_file}. Use --force to overwrite."
+            )
+
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        default_config_file = resources.files("ttydal").joinpath("default_config.json")
+        shutil.copy2(str(default_config_file), str(cfg_file))
+        return cfg_file
 
     def _save_config(self) -> None:
         """Save configuration to file."""
@@ -99,7 +134,7 @@ class ConfigManager:
     @property
     def debug_logging_enabled(self) -> bool:
         """Get the debug logging enabled setting."""
-        return self.get("debug_logging_enabled", True)
+        return self._debug_override or self.get("debug_logging_enabled", False)
 
     @debug_logging_enabled.setter
     def debug_logging_enabled(self, value: bool) -> None:
@@ -135,3 +170,24 @@ class ConfigManager:
     def vibrant_color(self, value: bool) -> None:
         """Set the vibrant color setting."""
         self.set("vibrant_color", value)
+
+    def get_keybinding(self, component: str, action: str) -> str:
+        """Get a keybinding for a specific component and action.
+
+        Args:
+            component: Component name (e.g., "app", "player_page", "albums_list")
+            action: Action name (e.g., "show_player", "toggle_play")
+
+        Returns:
+            Key binding string (e.g., "p", "space", "shift+left")
+        """
+        keybindings = self.get("keybindings", {})
+        defaults = self._get_default_keybindings()
+
+        # Get key from user config, fall back to default if not found
+        user_key = keybindings.get(component, {}).get(action)
+        if user_key is not None:
+            return user_key
+
+        # Fall back to default
+        return defaults.get(component, {}).get(action, "")

--- a/src/ttydal/default_config.json
+++ b/src/ttydal/default_config.json
@@ -1,0 +1,59 @@
+{
+  "theme": "rose-pine",
+  "quality": "high",
+  "auto_play": true,
+  "debug_logging_enabled": false,
+  "api_logging_enabled": false,
+  "keybindings": {
+    "navigation": {
+      "cursor_down": "down",
+      "cursor_up": "up",
+      "cursor_left": "left",
+      "cursor_right": "right"
+    },
+    "app": {
+      "show_player": "p",
+      "show_config": "c",
+      "focus_albums": "a",
+      "focus_tracks": "t",
+      "open_search": "/",
+      "open_cache_info": "i",
+      "toggle_play": "space",
+      "toggle_auto_play": "n",
+      "toggle_shuffle": "s",
+      "toggle_vibrant_color": "v",
+      "seek_backward": "shift+left",
+      "seek_forward": "shift+right",
+      "play_previous": "P",
+      "play_next": "N",
+      "quit": "q"
+    },
+    "player_page": {
+      "toggle_playback": "space"
+    },
+    "albums_list": {
+      "refresh_albums": "r"
+    },
+    "tracks_list": {
+      "play_selected_track": "enter",
+      "refresh_tracks": "r"
+    },
+    "search_modal": {
+      "close_modal": "escape",
+      "select_result": "enter",
+      "play_track": "space"
+    },
+    "cache_modal": {
+      "close_modal": "escape"
+    },
+    "login_modal": {
+      "open_url": "o",
+      "copy_url": "c",
+      "check_login": "l",
+      "close_modal": "escape"
+    },
+    "config_page": {
+      "toggle_switch": "space"
+    }
+  }
+}

--- a/src/ttydal/keybindings.py
+++ b/src/ttydal/keybindings.py
@@ -1,0 +1,39 @@
+"""Keybinding helper utilities for configurable keybindings."""
+
+from textual.binding import Binding
+from ttydal.config import ConfigManager
+
+
+def get_key(component: str, action: str) -> str:
+    """Get a keybinding from config.
+
+    Args:
+        component: Component name (e.g., "app", "player_page")
+        action: Action name (e.g., "show_player", "quit")
+
+    Returns:
+        Key binding string
+    """
+    config = ConfigManager()
+    return config.get_keybinding(component, action)
+
+
+def create_bindings(component: str, binding_specs: list[tuple[str, str, bool]]) -> list[Binding]:
+    """Create Binding objects from config for a specific component.
+
+    Args:
+        component: Component name (e.g., "app", "player_page")
+        binding_specs: List of (action, description, show) tuples
+
+    Returns:
+        List of Binding objects with keys from config
+    """
+    config = ConfigManager()
+    bindings = []
+
+    for action, description, show in binding_specs:
+        key = config.get_keybinding(component, action)
+        if key:
+            bindings.append(Binding(key, action, description, show=show))
+
+    return bindings

--- a/src/ttydal/pages/config_page.py
+++ b/src/ttydal/pages/config_page.py
@@ -225,15 +225,17 @@ class ConfigPage(Container):
         # Theme: preview and save immediately
         if event.select.id == "theme-select" and event.value:
             theme = str(event.value)
-            # Apply theme immediately for preview
+            if theme == self.config.theme:
+                return
             self.app.theme = theme
-            # Save to config
             self.config.theme = theme
             self.post_message(self.ThemeChanged(theme))
 
         # Quality: save immediately
         elif event.select.id == "quality-select" and event.value:
             quality = str(event.value)
+            if quality == self.config.quality:
+                return
             self.config.quality = quality
             self.post_message(self.QualityChanged(quality))
 
@@ -245,14 +247,20 @@ class ConfigPage(Container):
         """
         # Auto-play: save immediately
         if event.switch.id == "auto-play-switch":
+            if event.value == self.config.auto_play:
+                return
             self.config.auto_play = event.value
 
         # Debug logging: save immediately
         elif event.switch.id == "debug-logging-switch":
+            if event.value == self.config.debug_logging_enabled:
+                return
             self.config.debug_logging_enabled = event.value
 
         # API logging: save immediately
         elif event.switch.id == "api-logging-switch":
+            if event.value == self.config.api_logging_enabled:
+                return
             self.config.api_logging_enabled = event.value
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/src/ttydal/pages/config_page.py
+++ b/src/ttydal/pages/config_page.py
@@ -1,11 +1,16 @@
 """Config page for application settings."""
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Container, Vertical, VerticalScroll, Horizontal
 from textual.widgets import Label, Button, Select, Switch
 from textual.message import Message
 
 from ttydal.config import ConfigManager
+from ttydal.keybindings import get_key
+
+_nav = lambda action: get_key("navigation", action)
+_k = lambda action: get_key("config_page", action)
 
 
 class ConfigPage(Container):
@@ -31,6 +36,12 @@ class ConfigPage(Container):
         ("Rose Pine Dawn", "rose-pine-dawn"),
         ("Atom One Dark", "atom-one-dark"),
         ("Atom One Light", "atom-one-light"),
+    ]
+
+    BINDINGS = [
+        Binding(_nav("cursor_down"), "cursor_down", "Down", show=False),
+        Binding(_nav("cursor_up"), "cursor_up", "Up", show=False),
+        Binding(_k("toggle_switch"), "toggle_switch", "Toggle", show=False),
     ]
 
     DEFAULT_CSS = """
@@ -254,3 +265,21 @@ class ConfigPage(Container):
             self.post_message(self.LoginRequested())
         elif event.button.id == "clear-logs-btn":
             self.post_message(self.ClearLogsRequested())
+
+    def action_cursor_down(self) -> None:
+        """Move cursor down in focused widget."""
+        focused = self.app.focused
+        if isinstance(focused, Select):
+            focused.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move cursor up in focused widget."""
+        focused = self.app.focused
+        if isinstance(focused, Select):
+            focused.action_cursor_up()
+
+    def action_toggle_switch(self) -> None:
+        """Toggle focused switch widget."""
+        focused = self.app.focused
+        if isinstance(focused, Switch):
+            focused.toggle()

--- a/src/ttydal/pages/player_page.py
+++ b/src/ttydal/pages/player_page.py
@@ -11,13 +11,16 @@ from ttydal.services.mpv_playback_engine import MpvPlaybackEngine
 from ttydal.services.tidal_client import TidalClient
 from ttydal.config import ConfigManager
 from ttydal.services import PlaybackService
+from ttydal.keybindings import get_key
+
+_k = lambda action: get_key("player_page", action)
 
 
 class PlayerPage(Container):
     """Player page containing all playback UI components."""
 
     BINDINGS = [
-        Binding("space", "toggle_playback", "Play/Pause", show=False),
+        Binding(_k("toggle_playback"), "toggle_playback", "Play/Pause", show=False),
     ]
 
     DEFAULT_CSS = """


### PR DESCRIPTION
## Summary
- Adds fully configurable keybindings via `~/.ttydal/config.json`
- Ships a bundled `default_config.json` as the single source of truth for defaults
- Adds CLI flags: `--init-config`, `--force`, `--debug`

## Changes

### New files
- `src/ttydal/default_config.json` — bundled default configuration
- `src/ttydal/keybindings.py` — helper module for loading keybindings at import time
- `src/ttydal/pages/config_page.py` — config settings page
- `KEYBINDINGS.md` — keybindings documentation

### Modified files
- `config.py` — loads defaults from bundled JSON; removed auto-merge that silently mutated user config; added `init_config()` static method; `debug_logging_enabled` checks both runtime flag and config
- `__init__.py` — added argparse with `--init-config [--force]` and `--debug` flags; nice `--help` output with config and logging info
- `app.py` — all bindings use configurable keys via `get_key()`
- `albums_list.py`, `tracks_list.py`, `search_modal.py`, `cache_modal.py`, `login_modal.py`, `player_page.py` — bindings use configurable keys; navigation keys (hjkl/arrows) are configurable

### Behavioral changes
- `action_play_selected_track()` always plays the selected track from the beginning; toggle pause is handled by the app-level `toggle_play` binding
- Config file is never auto-created or silently changed on startup; app falls back to bundled defaults at runtime
- Users opt in to creating a config with `ttydal --init-config`
- `--debug` enables debug logging for the session without modifying config (overrides config)

## CLI
```
usage: ttydal [-h] [--init-config [--force]] [--debug]

options:
  --init-config  create default config at ~/.ttydal/config.json
  --force        overwrite existing config (only with --init-config)
  --debug        enable debug logging (overrides config)
```

## Testing
- [x] App works with no user config (falls back to bundled defaults)
- [x] `--init-config` creates config at `~/.ttydal/config.json`
- [x] `--init-config` refuses to overwrite without `--force`
- [x] `--force` errors when used without `--init-config`
- [x] `--debug` enables logging without modifying config file
- [x] Custom keybindings in config are respected
- [x] Missing keybindings fall back to defaults at runtime