### PR TITLE
Fix: track list numbering inconsistency

### DIFF
--- a/src/ttydal/components/tracks_list.py
+++ b/src/ttydal/components/tracks_list.py
@@ -382,14 +382,13 @@ class TracksList(Container):
         header = self.query_one(Label)
         header.update(f"(t)racks - {item_name} (Loading...)")
 
-        # Clear the list and start loading in a worker
-        list_view = self.query_one("#tracks-listview", ListView)
-        list_view.clear()
+        # Clear state immediately
         self.tracks = []
 
         # Run the loading in a worker so UI can update
+        # Use exclusive=True to cancel any previous loading workers
         self.run_worker(
-            self._load_tracks_async(item_id, item_name, item_type), exclusive=False
+            self._load_tracks_async(item_id, item_name, item_type), exclusive=True
         )
 
     async def _load_tracks_async(
@@ -403,6 +402,10 @@ class TracksList(Container):
             item_type: Type of item ('album', 'playlist', or 'favorites')
         """
         try:
+            # Await clear to ensure old items are fully removed from DOM
+            list_view = self.query_one("#tracks-listview", ListView)
+            await list_view.clear()
+
             # Check cache first
             cache = TracksCache()
             cached_tracks = cache.get(item_id)
@@ -428,8 +431,9 @@ class TracksList(Container):
 
             log(f"  - Retrieved {len(tracks_list)} tracks")
 
-            # Populate ALL tracks
-            list_view = self.query_one("#tracks-listview", ListView)
+            # Build tracks array locally then assign atomically
+            new_tracks = []
+
             for idx, track in enumerate(tracks_list, 1):
                 track_name = track["name"]
                 artist = track.get("artist", "Unknown")
@@ -443,7 +447,7 @@ class TracksList(Container):
                 list_view.append(
                     ListItem(CoverArtItem(display_text, cover_url=cover_url))
                 )
-                self.tracks.append(
+                new_tracks.append(
                     {
                         "id": str(track["id"]),
                         "name": track_name,
@@ -451,10 +455,12 @@ class TracksList(Container):
                         "album": album_name,
                         "duration": track["duration"],
                         "cover_url": cover_url,
+                        "index": idx,  # Store 1-indexed track number
                     }
                 )
 
-            log(f"  - Populated {len(self.tracks)} tracks in UI")
+            self.tracks = new_tracks
+            log(f"  - Loaded {len(self.tracks)} tracks")
 
             # Update header to remove loading text
             header = self.query_one(Label)
@@ -503,6 +509,7 @@ class TracksList(Container):
                     track_name = track["name"]
                     artist = track["artist"]
                     duration = self._format_duration(track["duration"])
+                    track_number = track.get("index", idx + 1)  # Use stored index or fallback
 
                     # Add ">" prefix if this is the currently playing track
                     # AND we're viewing the album that contains the playing track
@@ -512,7 +519,7 @@ class TracksList(Container):
                         else "  "
                     )
                     display_text = (
-                        f"{prefix}{idx + 1}. {track_name} - {artist} ({duration})"
+                        f"{prefix}{track_number}. {track_name} - {artist} ({duration})"
                     )
 
                     # Update the CoverArtItem text


### PR DESCRIPTION
## Summary
- Fixes track list numbering when switching between playlists/albums

## Problem
Two issues caused incorrect track numbering:

1. **Stale DOM children**: `ListView.clear()` returns an `AwaitRemove` awaitable. It was being called synchronously before spawning the async loading worker, so old DOM items were still present when new tracks were appended — causing numbering to start from the previous playlist's length (e.g. switching from a 25-track to a 149-track playlist would show tracks numbered 26–149).

2. **Virtualization mismatch**: `_update_track_indicators()` used the enumeration index from `list_view.children` for numbering, which could be incorrect due to ListView virtualization (only visible items exist in the DOM).

## Solution
- Move `list_view.clear()` into the async worker and properly `await` it
- Build tracks array locally and assign atomically to `self.tracks`
- Store 1-indexed track number in each track dict during load
- Use stored index in `_update_track_indicators()` instead of DOM enumeration index
- Use `exclusive=True` for the loading worker to cancel stale loaders

## Testing
- [x] Switch between playlists of different lengths (shorter → longer, longer → shorter)
- [x] Verify numbering always starts at 1
- [x] Verify track names match their numbers
- [x] Verify playing a track resets indicators correctly