### PR TITLE
feat: add configurable list striping

### DIFF
--- a/src/ttydal/app.py
+++ b/src/ttydal/app.py
@@ -600,6 +600,28 @@ class TtydalApp(App):
             log(f"Error clearing logs: {e}")
             self.notify(f"Error clearing logs: {e}", severity="error")
 
+    def on_config_page_list_striping_changed(
+        self, event: ConfigPage.ListStripingChanged
+    ) -> None:
+        """Handle list striping setting change.
+
+        Args:
+            event: List striping changed event
+        """
+        player_page = self.query_one(PlayerPage)
+        albums_list = player_page.query_one(AlbumsList)
+        tracks_list = player_page.query_one(TracksList)
+
+        if event.enabled:
+            albums_list.remove_class("no-stripes")
+            tracks_list.remove_class("no-stripes")
+        else:
+            albums_list.add_class("no-stripes")
+            tracks_list.add_class("no-stripes")
+
+        status = "enabled" if event.enabled else "disabled"
+        self.notify(f"List striping {status}", severity="information")
+
     def on_unmount(self) -> None:
         """Cleanup when application unmounts."""
         log("TtydalApp.on_unmount() called - cleaning up...")

--- a/src/ttydal/components/albums_list.py
+++ b/src/ttydal/components/albums_list.py
@@ -58,6 +58,10 @@ class AlbumsList(Container):
     AlbumsList ListItem:odd {
         background: $boost;
     }
+
+    AlbumsList.no-stripes ListItem:odd {
+        background: transparent;
+    }
     """
 
     class AlbumSelected(Message):
@@ -96,6 +100,11 @@ class AlbumsList(Container):
 
     def on_mount(self) -> None:
         """Load albums when mounted and auto-select My Tracks."""
+        from ttydal.config import ConfigManager
+
+        if not ConfigManager().list_striping:
+            self.add_class("no-stripes")
+
         # Delay loading to ensure session is ready
         log("AlbumsList.on_mount() called - scheduling delayed load")
         self.set_timer(0.5, self.delayed_load)

--- a/src/ttydal/components/tracks_list.py
+++ b/src/ttydal/components/tracks_list.py
@@ -59,6 +59,10 @@ class TracksList(Container):
     TracksList ListItem:odd {
         background: $boost;
     }
+
+    TracksList.no-stripes ListItem:odd {
+        background: transparent;
+    }
     """
 
     class TrackSelected(Message):
@@ -116,6 +120,11 @@ class TracksList(Container):
 
     def on_mount(self) -> None:
         """Initialize when mounted."""
+        from ttydal.config import ConfigManager
+
+        if not ConfigManager().list_striping:
+            self.add_class("no-stripes")
+
         # Register callbacks for track end and time position events
         if not self._track_end_callback_registered:
             from ttydal.services.mpv_playback_engine import MpvPlaybackEngine

--- a/src/ttydal/config.py
+++ b/src/ttydal/config.py
@@ -135,3 +135,13 @@ class ConfigManager:
     def vibrant_color(self, value: bool) -> None:
         """Set the vibrant color setting."""
         self.set("vibrant_color", value)
+
+    @property
+    def list_striping(self) -> bool:
+        """Get the list striping setting (alternating row backgrounds)."""
+        return self.get("list_striping", True)
+
+    @list_striping.setter
+    def list_striping(self, value: bool) -> None:
+        """Set the list striping setting."""
+        self.set("list_striping", value)

--- a/src/ttydal/pages/config_page.py
+++ b/src/ttydal/pages/config_page.py
@@ -128,6 +128,13 @@ class ConfigPage(Container):
 
         pass
 
+    class ListStripingChanged(Message):
+        """Message sent when list striping setting changes."""
+
+        def __init__(self, enabled: bool) -> None:
+            super().__init__()
+            self.enabled = enabled
+
     def __init__(self):
         """Initialize the config page."""
         super().__init__()
@@ -170,6 +177,10 @@ class ConfigPage(Container):
                 with Horizontal():
                     yield Label("Auto-Play Next Track:")
                     yield Switch(value=self.config.auto_play, id="auto-play-switch")
+
+                with Horizontal():
+                    yield Label("List Striping:")
+                    yield Switch(value=self.config.list_striping, id="list-striping-switch")
 
                 # Tidal Account section
                 yield Label("")
@@ -235,6 +246,11 @@ class ConfigPage(Container):
         # Auto-play: save immediately
         if event.switch.id == "auto-play-switch":
             self.config.auto_play = event.value
+
+        # List striping: save and notify for live update
+        elif event.switch.id == "list-striping-switch":
+            self.config.list_striping = event.value
+            self.post_message(self.ListStripingChanged(event.value))
 
         # Debug logging: save immediately
         elif event.switch.id == "debug-logging-switch":


### PR DESCRIPTION
## Summary

- Adds a `list_striping` config option (default: `true`) to toggle alternating row backgrounds in the albums and tracks lists
- New toggle in the Config page for live switching
- Uses a CSS class override (`no-stripes`) so the existing `:odd` styling is preserved by default

Prompted by feedback in #5 about making the stripe styling configurable.

## Changes

- `config.py`: new `list_striping` property
- `albums_list.py` / `tracks_list.py`: `.no-stripes` CSS override + `on_mount` config check
- `config_page.py`: new switch + `ListStripingChanged` message
- `app.py`: handler to toggle the class live on both lists